### PR TITLE
Fix utf-8 overlong check

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -221,7 +221,7 @@ impl CharExt for char {
         };
         if let Some(i) = bytes.iter().skip(1).position(|&b| (b >> 6) != 0b10 ) {
             Err(Utf8(NotAContinuationByte(i+1)))
-        } else if overlong(bytes[0], bytes[1]) {
+        } else if overlong(src) {
             Err(Utf8(OverLong))
         } else {
             let c = unsafe{ char::from_utf8_exact_slice_unchecked(bytes) };
@@ -242,7 +242,7 @@ impl CharExt for char {
         };
         if let Some(i) = src[1..].iter().position(|&b| (b >> 6) != 0b10 ) {
             Err(Utf8(NotAContinuationByte(i+1)))
-        } else if overlong(utf8[0], utf8[1]) {
+        } else if overlong(&utf8[..]) {
             Err(Utf8(OverLong))
         } else {
             let c = unsafe{ char::from_utf8_exact_slice_unchecked(src) };
@@ -340,16 +340,39 @@ impl CharExt for char {
     }
 }
 
-
-// If all the data bits in the first byte are zero, the sequence might be longer than necessary
-// When you go up one byte, you gain 6-1 data bits, so if the five first are zero it's too long.
-// The first byte has 3 + (4-len) data bits, which we know are zero.
-// The first two bits in the second byte are 10, which gets shifted out.
-fn overlong(first: u8,  second: u8) -> bool {
-    let both = ((first as u16) << 8)  |  (second << 2) as u16;
-    let both = both << 1+both.not().leading_zeros();
-    both.leading_zeros() >= 5
+// Only called with slices with 0 < data.len() <= 4
+// Assumes that the input is valid except for possibly overlongness and surrogate code points
+// Adapted from https://www.cl.cam.ac.uk/~mgk25/ucs/utf8_check.c
+fn overlong(s: &[u8]) -> bool {
+    if s[0] < 0x80 {
+        false
+    } else if (s[0] & 0xe0) == 0xc0 {
+        ((s[1] & 0xc0) != 0x80) || ((s[0] & 0xfe) == 0xc0)
+    } else if (s[0] & 0xf0) == 0xe0 {
+        (s[1] & 0xc0) != 0x80 ||
+        (s[2] & 0xc0) != 0x80 ||
+        (s[0] == 0xe0 && (s[1] & 0xe0) == 0x80)
+    } else {
+        (s[1] & 0xc0) != 0x80 ||
+        (s[2] & 0xc0) != 0x80 ||
+        (s[3] & 0xc0) != 0x80 ||
+        (s[0] == 0xf0 && (s[1] & 0xf0) == 0x80)
+    }
 }
+
+// // If all the data bits in the first byte are zero, the sequence might be longer than necessary
+// // When you go up one byte, you gain 6-1 data bits, so if the five first are zero it's too long.
+// // The first byte has 3 + (4-len) data bits, which we know are zero.
+// // The first two bits in the second byte are 10, which gets shifted out.
+// fn overlong(first: u8,  second: u8) -> bool {
+//     let encoded: u16 = (second & 0b0011_1111) as u16;
+//     // let both = ((first as u16) << 8)  |  (second << 2) as u16;
+//     // println!("{:016b}", both);
+//     // println!("{:016b}", both.not());
+//     // let both = both << 1+both.not().leading_zeros();
+//     // println!("{:016b}\n", both);
+//     // both.leading_zeros() >= 5
+// }
 
 // Create a `char` from a leading and a trailing surrogate.
 unsafe fn combine_surrogates(first: u16, second: u16) -> char {

--- a/tests/errs.rs
+++ b/tests/errs.rs
@@ -107,7 +107,8 @@ fn from_utf16_slice_start() {
 fn overlong_utf8() {
     use encode_unicode::error::InvalidUtf8::OverLong;
     let overlongs = [[0xc0,0xbf], [0xe0,0x9f], [0xf0,0x8f],
-                     [0xc0,0x9f], [0xe0,0x8f], [0xf0,0x87]];
+                     [0xc0,0x9f], [0xe0,0x8f], [0xf0,0x87],
+                     [0xc1, 0x92]];
     for o in overlongs.iter() {
         let arr = [o[0],o[1], 0x80, 0x80];
         assert_eq!(char::from_utf8_slice_start(&arr), Err(InvalidUtf8Slice::Utf8(OverLong)));


### PR DESCRIPTION
Fixes https://github.com/tormol/encode_unicode/issues/6

This code is neither clever nor optimized, but it seems to be correct.