### PR TITLE
Add fuzz test for Utf8Char::from_slice_start

### DIFF
--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+
+target
+corpus
+artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,22 @@
+
+[package]
+name = "encode_unicode-fuzz"
+version = "0.0.1"
+authors = ["Automatically generated"]
+publish = false
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies.encode_unicode]
+path = ".."
+[dependencies.libfuzzer-sys]
+git = "https://github.com/rust-fuzz/libfuzzer-sys.git"
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "utf8char_from_slice_start"
+path = "fuzz_targets/utf8char_from_slice_start.rs"

--- a/fuzz/fuzz_targets/utf8char_from_slice_start.rs
+++ b/fuzz/fuzz_targets/utf8char_from_slice_start.rs
@@ -1,0 +1,16 @@
+#![no_main]
+#[macro_use]
+extern crate libfuzzer_sys;
+extern crate encode_unicode;
+
+use encode_unicode::Utf8Char;
+
+fuzz_target!(|data: &[u8]| {
+    if data.len() > 0 {
+        // validate the result of encode_unicode against the std library
+        match Utf8Char::from_slice_start(data) {
+            Err(_) => assert!(std::str::from_utf8(data).is_err()),
+            Ok((c, len)) => assert_eq!(c.as_str(), std::str::from_utf8(&data[..len]).unwrap()),
+        }
+    }
+});


### PR DESCRIPTION
Adds a fuzz test that checks whether the behavior of `Utf8Char::from_slice_start` matches that of the std library.

To use, [install](https://fuzz.rs/book/cargo-fuzz/setup.html#installing) cargo-fuzz, then run `cargo fuzz run utf8char_from_slice_start`.