### PR TITLE
Mark trait `U16UtfExt` as unsafe as an incorrect implementation could lead to undefined behaviour.

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -119,7 +119,10 @@ impl U8UtfExt for u8 {
 
 
 /// Methods for working with `u16`s as UTF-16 units.
-pub trait U16UtfExt {
+///
+/// This trait is marked as unsafe because avoiding undefined behaviour
+/// necessarily depends on it being implemented correctly.
+pub unsafe trait U16UtfExt {
     /// Will you need an extra unit to complete this codepoint?
     ///
     /// Returns `Err` for trailing surrogates, `Ok(true)` for leading surrogates,
@@ -132,7 +135,7 @@ pub trait U16UtfExt {
     /// Is basically an unchecked variant of `utf16_needs_extra_unit()`.
     fn is_utf16_leading_surrogate(self) -> bool;
 }
-impl U16UtfExt for u16 {
+unsafe impl U16UtfExt for u16 {
     #[inline]
     fn utf16_needs_extra_unit(self) -> Result<bool,Utf16FirstUnitError> {
         match self {


### PR DESCRIPTION
There are parts of the code that depend on the implementation of `U16UtfExt` being correct in order to avoid undefined behaviour. Examples:
https://github.com/tormol/encode_unicode/blob/b764bc1cec904d2198b052c5a564963a930a0bcb/src/decoding_iterators.rs#L380
https://github.com/tormol/encode_unicode/blob/b764bc1cec904d2198b052c5a564963a930a0bcb/src/decoding_iterators.rs#L383

These call sites of the trait's methods do not defend against its implementation being incorrect. We therefore think it would be a good idea to mark the trait as unsafe to make it clear that the overall safety of the crate depends on it.